### PR TITLE
Suggested hardware focus 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Such an initiative has inevitable real-world costs. We aim to keep these as lean
 
 ## Focus 
 
-There has been considerable advancements in software primitives in our space. We are, however, losing sight of some original cypherpunk ideals of self-sovereignty, and running your own hardware infra.
+There have been considerable advancements in software primitives in our space. We are, however, losing sight of some original cypherpunk ideals of self-sovereignty, and running your own hardware infra.
 
 As such, we welcome all hardware and software hackers to attend an open hackspace for experimentation and a series of practical workshops on various topics, relating to the intersection of hardware and software. 
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Such an initiative has inevitable real-world costs. We aim to keep these as lean
 
 ## Focus 
 
-There has been considerable advancements in primitives in our space, but we risk losing sight of some original cypherpunk ideals of self-sovereignty. We welcome all hardware and software hackers to attend an open workspace and a series of practical workshops.  
+There has been considerable advancements in primitives in our space, but we risk losing sight of some original cypherpunk ideals of self-sovereignty. We welcome all hardware and software hackers to attend an open hackspace for experimentation and a series of practical workshops on various topics. 
 
 Topics
 
@@ -31,19 +31,20 @@ Topics
    - distributed validator technology
  - communications and media
    - personal devices and HCI
-   - backend infra
-   - p2p networking infra
- - zk
-   - accelerating hardware: FPGAs, GPUs
+   - backend infra  
+   - p2p networking infra 
+ - proving and acceleration
+   - FPGAs, GPUs 
    - client side proving
    - participating in proving markets
+  
      
 Structure: 
  - Open hack space
  - workshops
  - closing ceremony showcase and findings 
 
-BYOH: Bring your own hardware. Think rasbperrypi, pinephhone, rock5b, GPUs, FPGAs, pinewatch..etc. 
+BYOH: Bring your own hardware. Think rasbperrypi, pinephhone, rock5b, GPUs, FPGAs, pinewatch, 3d printers..etc. 
 
 ## Venue
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Such an initiative has inevitable real-world costs. We aim to keep these as lean
 
 ## Focus 
 
-There has been considerable advancements in software primitives in our space, but we risk losing sight of some original cypherpunk ideals of self-sovereignty, and running your own hardware. We welcome all hardware and software hackers to attend an open hackspace for experimentation and a series of practical workshops on various topics, relating to the intersection of hardware ans software. 
+There has been considerable advancements in software primitives in our space. We are, however, losing sight of some original cypherpunk ideals of self-sovereignty, and running your own hardware infra.
+
+As such, we welcome all hardware and software hackers to attend an open hackspace for experimentation and a series of practical workshops on various topics, relating to the intersection of hardware and software. 
 
 ### Topics
 
@@ -41,14 +43,6 @@ There has been considerable advancements in software primitives in our space, bu
    - booting and deployment
    - configuration management
    - software development lifecycle
- - layer 1 - network
-   - blobs
-   - verkle tries
-   - world computer 2.0
- - layer 0 - community
-   - collaboration
-   - coordination
-   - connection
  - open standards
    - software
    - hardware
@@ -61,7 +55,7 @@ There has been considerable advancements in software primitives in our space, bu
 
 ### BYOH: Bring your own hardware.
 
-Think rasbperrypi, pinephhone, rock5b, GPUs, FPGAs, pinewatch, 3d printers, TVs, ATMs, cameras, microphones, screens, speakers..etc. 
+Think rasbperrypi, pinephone, rock5b, GPU, FPGA, pinewatch, 3d printers, TVs, ATMs, cameras, microphones, screens, speakers, etc. 
 
 ## Venue
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ There has been considerable advancements in software primitives in our space, bu
    - FPGAs, GPUs 
    - client side proving
    - participating in proving markets
+ - operations
+   - booting and deployment
+   - configuration management
+   - software development lifecycle
+   - human resources
  - layer 1 - network
    - blobs
    - verkle tries

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Such an initiative has inevitable real-world costs. We aim to keep these as lean
 
 ## Focus 
 
-There has been considerable advancements in primitives in our space, but we risk losing sight of some original cypherpunk ideals of self-sovereignty. We welcome all hardware and software hackers to attend an open hackspace for experimentation and a series of practical workshops on various topics. 
+There has been considerable advancements in software primitives in our space, but we risk losing sight of some original cypherpunk ideals of self-sovereignty, and running your own hardware. We welcome all hardware and software hackers to attend an open hackspace for experimentation and a series of practical workshops on various topics, relating to the intersection of hardware ans software. 
 
-Topics
+### Topics
 
  - running your own node
    - RPC endpoints
@@ -37,14 +37,27 @@ Topics
    - FPGAs, GPUs 
    - client side proving
    - participating in proving markets
-  
-     
-Structure: 
- - Open hack space
- - workshops
- - closing ceremony showcase and findings 
+ - layer 1 - network
+   - blobs
+   - verkle tries
+   - world computer 2.0
+ - layer 0 - community
+   - collaboration
+   - coordination
+   - connection
+ - open standards
+   - software
+   - hardware
 
-BYOH: Bring your own hardware. Think rasbperrypi, pinephhone, rock5b, GPUs, FPGAs, pinewatch, 3d printers..etc. 
+### Structure 
+ - Open Hack Space
+ - Workshops
+ - Show and Tell
+ - Closing Ceremony 
+
+### BYOH: Bring your own hardware.
+
+Think rasbperrypi, pinephhone, rock5b, GPUs, FPGAs, pinewatch, 3d printers, TVs, ATMs, cameras, microphones, screens, speakers..etc. 
 
 ## Venue
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,32 @@ Hack-to-Hack is an initiative to empower interoperability between hackers, and b
 
 Such an initiative has inevitable real-world costs. We aim to keep these as lean as possible, while providing a comfortable environment for collaborating, hacking, and enjoying. Costs largely relate to rental of a location, and tables / chairs / power / internet, to provide basic needs for a hacking co-work. We propose to provide minimal catering, and instead to inform participants about local options for food and drink, as a way to encourage hackers to get to know the city of Prague.
 
+## Focus 
+
+There has been considerable advancements in primitives in our space, but we risk losing sight of some original cypherpunk ideals of self-sovereignty. We welcome all hardware and software hackers to attend an open workspace and a series of practical workshops.  
+
+Topics
+
+ - running your own node
+   - RPC endpoints
+   - restaking
+   - distributed validator technology
+ - communications and media
+   - personal devices and HCI
+   - backend infra
+   - p2p networking infra
+ - zk
+   - accelerating hardware: FPGAs, GPUs
+   - client side proving
+   - participating in proving markets
+     
+Structure: 
+ - Open hack space
+ - workshops
+ - closing ceremony showcase and findings 
+
+BYOH: Bring your own hardware. Think rasbperrypi, pinephhone, rock5b, GPUs, FPGAs, pinewatch..etc. 
+
 ## Venue
 
 In terms of venue, the event will be similar to Devconnect Coworking in Istanbul. The basic aim is to provide a comfortable environment for collaborating, hacking, and enjoying - while keeping a sustainable budget without excessive spending.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ There has been considerable advancements in software primitives in our space, bu
    - booting and deployment
    - configuration management
    - software development lifecycle
-   - human resources
  - layer 1 - network
    - blobs
    - verkle tries
@@ -94,3 +93,5 @@ This event is intended to be non-profit and community based. We would be glad fo
 ## Contributor
 
 * [@burningtree](https://github.com/burningtree)
+* [@mohammed7s](https://github.com/mohammed7s)
+* [@chrishobcroft](https://github.com/chrishobcroft)


### PR DESCRIPTION
There has not been many focused events (if any at all) on hardware. Given it is an event between hacks, having a playful and relaxed environment where people come and try any hardware project with support from the best hackers in the space, and learn about things that are usually not discussed in typical ETH conferences. 

We suggest having the hackerspace open for hardware and software hackers that wish to bring their own hardware and play around with ideas and connecting things together. Also, to invite experts to give hands on and practical workshops on various topics and a bunch of whiteboard sessions on things like FPGAs design, Booting from decentralized storage, setting up DVT nodes with friends...etc. No talks. Just maintaining the same hackerspace vibe with some enabling tools, environment, mentors. 

I have spoken to people in my network that would be present in Prague and expressed excitement for the idea and interest in bringing their own hardware, and spoke to potential workshop speakers and mentors. 